### PR TITLE
Enable full access on StudentsDCID field for extension tables

### DIFF
--- a/src/plugin.xml
+++ b/src/plugin.xml
@@ -39,7 +39,7 @@
     <field table="students" field="transferComment" access="FullAccess" />
     <field table="students" field="zip" access="FullAccess" />
 
-    <field table="s_ok_stu_x" field="studentsDcid" access="ViewOnly" />
+    <field table="s_ok_stu_x" field="studentsDcid" access="FullAccess" />
     <field table="s_ok_stu_x" field="armedForces" access="FullAccess" />
     <field table="s_ok_stu_x" field="birthAuthority" access="FullAccess" />
     <field table="s_ok_stu_x" field="birthCity" access="FullAccess" />
@@ -76,7 +76,7 @@
     <field table="s_ok_stu_x" field="migrant" access="FullAccess" />
     <field table="s_ok_stu_x" field="immigrant" access="FullAccess" />
 
-    <field table="u_studentsUserFields" field="studentsDcid" access="ViewOnly" />
+    <field table="u_studentsUserFields" field="studentsDcid" access="FullAccess" />
     <field table="u_studentsUserFields" field="tps_alert_services" access="FullAccess" />
     <field table="u_studentsUserFields" field="tps_demographics_home_sch" access="FullAccess" />
     <field table="u_studentsUserFields" field="tps_demographics_preferredFI01" access="FullAccess" />
@@ -94,7 +94,7 @@
     <field table="u_studentsUserFields" field="tps_natamer_tribes" access="FullAccess" />
     <field table="u_studentsUserFields" field="tps_natamer_cherokee_rollnbr" access="FullAccess" />
 
-    <field table="u_tps_indian_education" field="studentsDcid" access="ViewOnly" />
+    <field table="u_tps_indian_education" field="studentsDcid" access="FullAccess" />
     <field table="u_tps_indian_education" field="identify_native_american" access="FullAccess" />
     <field table="u_tps_indian_education" field="tribal_member" access="FullAccess" />
     <field table="u_tps_indian_education" field="tribal_member_name" access="FullAccess" />


### PR DESCRIPTION
The StudentsDCID field needs to be FullAccess to permit the creation (POST) of the records in the student extension tables.

- `S_OK_STU_X`.`StudentsDCID`
- `U_StudentsUserFields`.`StudentsDCID`
- `U_TPS_Indian_Education`.`StudentsDCID`

These records are not automatically created when the student record is created.

## References

- https://support.powerschool.com/developer/#/page/table-resources
- https://support.powerschool.com/developer/#/page/general-usage